### PR TITLE
Bugfix for multiple vm and program arguments in product file

### DIFF
--- a/maven-osgi-package-plugin/src/main/java/at/bestsolution/maven/osgi/pack/ProductPackagePlugin.java
+++ b/maven-osgi-package-plugin/src/main/java/at/bestsolution/maven/osgi/pack/ProductPackagePlugin.java
@@ -15,7 +15,7 @@ import java.io.PrintWriter;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.jar.JarFile;
-
+import java.util.stream.Collectors;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -67,19 +67,14 @@ public class ProductPackagePlugin extends AbstractMojo {
 
         Xpp3Dom launcherArgs = new Xpp3Dom("launcherArgs");
         Xpp3Dom programArgs = new Xpp3Dom("programArgs");
-        StringBuilder programArgsVal = new StringBuilder();
-        for (String a : product.launcherArgs.programArguments) {
-            programArgsVal.append(a + " ");
-        }
-        programArgs.setValue(programArgsVal.toString());
+        programArgs.setValue(product.launcherArgs.programArguments.stream().collect(Collectors.joining(" ")));
         launcherArgs.addChild(programArgs);
 
         Xpp3Dom vmArgs = new Xpp3Dom("vmArgs");
-        StringBuilder vmArgsVal = new StringBuilder();
-        for (Entry<Object, Object> e : product.launcherArgs.vmProperties.entrySet()) {
-            vmArgsVal.append("-D" + e.getKey() + "=" + e.getValue() + " ");
-        }
-        vmArgs.setValue(vmArgsVal.toString());
+        vmArgs.setValue(
+        	product.launcherArgs.vmProperties.entrySet().stream()
+        		.map( e -> "-D" + e.getKey() + "=" + e.getValue())
+        		.collect(Collectors.joining(" ")));
         launcherArgs.addChild(vmArgs);
 
         xppProduct.addChild(launcherArgs);

--- a/maven-osgi-package-plugin/src/main/java/at/bestsolution/maven/osgi/pack/ProductPackagePlugin.java
+++ b/maven-osgi-package-plugin/src/main/java/at/bestsolution/maven/osgi/pack/ProductPackagePlugin.java
@@ -67,16 +67,19 @@ public class ProductPackagePlugin extends AbstractMojo {
 
         Xpp3Dom launcherArgs = new Xpp3Dom("launcherArgs");
         Xpp3Dom programArgs = new Xpp3Dom("programArgs");
+        StringBuilder programArgsVal = new StringBuilder();
         for (String a : product.launcherArgs.programArguments) {
-            programArgs.setValue(a);
+            programArgsVal.append(a + " ");
         }
+        programArgs.setValue(programArgsVal.toString());
         launcherArgs.addChild(programArgs);
 
         Xpp3Dom vmArgs = new Xpp3Dom("vmArgs");
+        StringBuilder vmArgsVal = new StringBuilder();
         for (Entry<Object, Object> e : product.launcherArgs.vmProperties.entrySet()) {
-            vmArgs.setValue("-D" + e.getKey() + "=" + e.getValue());
+            vmArgsVal.append("-D" + e.getKey() + "=" + e.getValue() + " ");
         }
-
+        vmArgs.setValue(vmArgsVal.toString());
         launcherArgs.addChild(vmArgs);
 
         xppProduct.addChild(launcherArgs);


### PR DESCRIPTION
Previously, even if the POM file for the product specified multiple `vmProperties` and `programArguments`, only one of them would be written to the final product file and therefore to the `.ini` file generated with the native-launcher. 

Here, I'm attempting to fix that problem. The culprit is that setting the value of the DOM element within the loop replaces the existing contents of the element. 