### PR TITLE
Fixed default value for exec.mode and added tests to multi-module build.

### DIFF
--- a/maven-osgi-exec-plugin/src/main/java/at/bestsolution/maven/osgi/exec/MVNBaseOSGiLaunchPlugin.java
+++ b/maven-osgi-exec-plugin/src/main/java/at/bestsolution/maven/osgi/exec/MVNBaseOSGiLaunchPlugin.java
@@ -67,7 +67,7 @@ public abstract class MVNBaseOSGiLaunchPlugin extends AbstractMojo {
 	@Parameter(defaultValue = "${project.build.finalName}")
 	private String filename;
 
-	@Parameter(property = "exec.mode", defaultValue = "START")
+	@Parameter(property = "exec.mode", defaultValue = "start")
 	protected Mode mode;
 
 	@Parameter

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 	</description>
 	<modules>
 		<module>maven-osgi-exec-plugin</module>
+		<module>maven-osgi-exec-plugin-tests</module>
 		<module>maven-osgi-package-plugin</module>
 		<module>tycho-lifecycle-controller</module>
 		<module>maven-osgi-targetplatform-lib</module>


### PR DESCRIPTION
The default value for exec.mode is now "start" instead of "START".
The plugin tests are also added to the multi-module build.