### PR TITLE
Fix for argument index in `String.format` that throws exception in Java 16+

### DIFF
--- a/maven-osgi-package-plugin/src/main/java/at/bestsolution/maven/osgi/pack/P2RepositoryPackagePlugin.java
+++ b/maven-osgi-package-plugin/src/main/java/at/bestsolution/maven/osgi/pack/P2RepositoryPackagePlugin.java
@@ -66,7 +66,7 @@ public class P2RepositoryPackagePlugin extends AbstractMojo {
         project.getArtifacts().stream().filter(this::pomFilter).forEach(a -> {
 
             String coloredOsgiFlag = getOsgiVerifier().isBundle(a) ? "true" : DebugSupport.TerminalOutputStyling.RED.style("false");
-            String message = String.format("Processing artifact: %0$-70s - OSGI Bundle: %s", formatArtifact(a), coloredOsgiFlag);
+            String message = String.format("Processing artifact: %1$-70s - OSGI Bundle: %s", formatArtifact(a), coloredOsgiFlag);
             logger.debug(message);
 
             try (JarFile f = new JarFile(a.getFile())) {


### PR DESCRIPTION
The argument index for `String.format` starts from `1`. In Java 11, index `0` defaulted to the first argument provided after the format string. However, in Java 17, this throws `IllegalFormatArgumentIndexException`