### PR TITLE
Feature to add VM options in addition to VM properties

### DIFF
--- a/maven-osgi-package-plugin/src/main/java/at/bestsolution/maven/osgi/pack/LauncherArgs.java
+++ b/maven-osgi-package-plugin/src/main/java/at/bestsolution/maven/osgi/pack/LauncherArgs.java
@@ -16,5 +16,6 @@ import java.util.Properties;
 public class LauncherArgs {
 	public List<String> programArguments;
 	public Properties vmProperties;
+	public List<String> vmOptions;
 	
 }

--- a/maven-osgi-package-plugin/src/main/java/at/bestsolution/maven/osgi/pack/P2RepositoryPackagePlugin.java
+++ b/maven-osgi-package-plugin/src/main/java/at/bestsolution/maven/osgi/pack/P2RepositoryPackagePlugin.java
@@ -66,7 +66,7 @@ public class P2RepositoryPackagePlugin extends AbstractMojo {
         project.getArtifacts().stream().filter(this::pomFilter).forEach(a -> {
 
             String coloredOsgiFlag = getOsgiVerifier().isBundle(a) ? "true" : DebugSupport.TerminalOutputStyling.RED.style("false");
-            String message = String.format("Processing artifact: %0$-70s - OSGI Bundle: %s", formatArtifact(a), coloredOsgiFlag);
+            String message = String.format("Processing artifact: %1$-70s - OSGI Bundle: %s", formatArtifact(a), coloredOsgiFlag);
             logger.debug(message);
 
             try (JarFile f = new JarFile(a.getFile())) {

--- a/maven-osgi-package-plugin/src/main/java/at/bestsolution/maven/osgi/pack/ProductPackagePlugin.java
+++ b/maven-osgi-package-plugin/src/main/java/at/bestsolution/maven/osgi/pack/ProductPackagePlugin.java
@@ -69,12 +69,13 @@ public class ProductPackagePlugin extends AbstractMojo {
         Xpp3Dom programArgs = new Xpp3Dom("programArgs");
         programArgs.setValue(product.launcherArgs.programArguments.stream().collect(Collectors.joining(" ")));
         launcherArgs.addChild(programArgs);
-
+        
         Xpp3Dom vmArgs = new Xpp3Dom("vmArgs");
         vmArgs.setValue(
-        	product.launcherArgs.vmProperties.entrySet().stream()
-        		.map( e -> "-D" + e.getKey() + "=" + e.getValue())
-        		.collect(Collectors.joining(" ")));
+    		product.launcherArgs.vmOptions.stream().collect(Collectors.joining(" "))
+        		+ product.launcherArgs.vmProperties.entrySet().stream()
+					.map( e -> "-D" + e.getKey() + "=" + e.getValue())
+					.collect(Collectors.joining(" ")));
         launcherArgs.addChild(vmArgs);
 
         xppProduct.addChild(launcherArgs);


### PR DESCRIPTION
For Java 17, sometimes the launch configuration needs to add VM options such as `--add-opens`. Currently, there is no option to specify such options that get passed on directly to the launcher. This is a proposal for such an addition.